### PR TITLE
Add initialize with static connection info

### DIFF
--- a/example/agent/flutter-example/lib/main.dart
+++ b/example/agent/flutter-example/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:infra_did_comm_dart/infra_did_comm_dart.dart';
 import 'package:qr_code_scanner/qr_code_scanner.dart';
@@ -208,7 +210,19 @@ class _MyHomePageState extends State<MyHomePage> {
         lastScan = currentScan;
         String data = scanData.code!;
         print("Scanned data: $data");
-        await agent.sendDIDAuthInitMessage(data);
+        if (data.contains("..")) {
+          await agent.sendDIDAuthInitMessage(data);
+        } else {
+          final decoded = base64.decode(data);
+          final jsonString = utf8.decode(decoded);
+          var decodedJson = jsonDecode(jsonString);
+          var did = decodedJson["did"];
+          var serviceEndpoint = decodedJson["serviceEndpoint"];
+          var context = Context.fromJson(decodedJson["context"]);
+
+          await agent.initWithStaticConnectRequest(
+              did, serviceEndpoint, context);
+        }
       }
     });
   }


### PR DESCRIPTION
# Overview

Add initialize with static connection info

## Example

```dart
  initWithStaticConnectRequest(
    String did,
    String serviceEndpoint,
    Context context,
  ) async {
    // Initialize with static connection only can be done by HOLDER
    changeRole("HOLDER");
    await connect();

    int currentTime = DateTime.now().millisecondsSinceEpoch ~/ 1000;
    await Future.delayed(Duration(milliseconds: 500));
    String socketId = (await this.socketId)!;

    Initiator initiator = Initiator(
      type: role,
      serviceEndpoint: url,
      socketId: socketId,
    );

    DIDConnectRequestMessage didConnectRequestMessage =
        DIDConnectRequestMessage(
      from: did,
      createdTime: currentTime,
      expiresTime: currentTime + 30000,
      context: context,
      initiator: initiator,
    );
    final encodedMessage =
        didConnectRequestMessage.encode(CompressionLevel.compactJSON);

    await http.get(Uri.parse("$serviceEndpoint?data=$encodedMessage"));
  }
```